### PR TITLE
Changed LocationManagerConfigurable

### DIFF
--- a/OpenStreetAmenities/Protocols/Extensions/CLLocationManagerExtension.swift
+++ b/OpenStreetAmenities/Protocols/Extensions/CLLocationManagerExtension.swift
@@ -10,14 +10,14 @@ import CoreLocation
 
 // CoreLocation extenstion for protocol conformance
 extension CLLocationManager: LocationManagerConfigurable {
-    func setDelegate(to instance: AnyObject) {
-        guard let delegate = instance as? CLLocationManagerDelegate else {
+    func setDelegate(to instance: CLLocationManagerDelegate?) {
+        guard let delegate = instance else {
             return
         }
         self.delegate = delegate
     }
-    func setDesiredAccuracy(to accuracy: Double) {
-        let accuracy = accuracy as CLLocationAccuracy
+	// Changed this because CLLocationAccuracy is just a typealias for Double
+    func setDesiredAccuracy(to accuracy: CLLocationAccuracy) {
         self.desiredAccuracy = accuracy
     }
 }

--- a/OpenStreetAmenities/Protocols/LocationManagerConfigurable.swift
+++ b/OpenStreetAmenities/Protocols/LocationManagerConfigurable.swift
@@ -8,8 +8,8 @@
 
 protocol LocationManagerConfigurable {
     // wrap var delegate and desiredAccuracy to keep it platform agnostic
-    func setDelegate(to instance: AnyObject)
-    func setDesiredAccuracy(to accuracy: Double)
+    func setDelegate(to instance: CLLocationManagerDelegate?)
+    func setDesiredAccuracy(to accuracy: CLLocationAccuracy)
     func requestAlwaysAuthorization()
     func startUpdatingLocation()
 }


### PR DESCRIPTION
Changed LocationManagerConfigurable protocol to pass in CLLocationManagerDelegate and CLLocationAccuracy in the setDelegate and setDesiredAccurary functions.